### PR TITLE
Upate libs to latest and fix ConductorComponentLifecycleHandler generation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,13 +8,12 @@ plugins {
 
 
 android {
-    compileSdk 33
-    buildToolsVersion = "33.0.1"
+    compileSdk 35
 
     defaultConfig {
         applicationId "com.funnydevs.hilt_conductor.demo"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 35
         versionCode 1
         versionName "1.0"
         multiDexEnabled = true

--- a/app/src/main/java/com/funnydevs/hilt_conductor/demo/MainActivity.kt
+++ b/app/src/main/java/com/funnydevs/hilt_conductor/demo/MainActivity.kt
@@ -1,10 +1,10 @@
 package com.funnydevs.hilt_conductor.demo
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.bluelinelabs.conductor.Conductor.attachRouter
 import com.bluelinelabs.conductor.Router
 import com.bluelinelabs.conductor.RouterTransaction
-import com.bluelinelabs.conductor.attachRouter
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -15,7 +15,7 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        mainRouter = attachRouter(findViewById(R.id.container), savedInstanceState)
+        mainRouter = attachRouter(this, findViewById(R.id.container), savedInstanceState)
         mainRouter.setRoot(RouterTransaction.with(MainController(null)))
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'com.android.tools.build:gradle:8.8.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$versions.hilt"
         classpath "io.github.funnydevs:hilt-conductor-plugin:$VERSION"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,10 +2,10 @@ ext.versions = [
 
 
         appcompat               : "1.6.1",
-        kotlin                  : '1.8.0',
-        conductor               : "3.0.0-rc4",
+        kotlin                  : '2.1.10',
+        conductor               : "4.0.0-preview-4",
         timber                  : "4.7.1",
-        hilt                    : '2.49',
+        hilt                    : '2.55',
         navigation              : "2.3.4",
         material                : "1.9.0",
         asm                     : "9.6",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Dec 08 11:42:47 CST 2023
+#Sun Feb 02 21:46:31 CET 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -4,12 +4,11 @@ plugins {
 }
 
 android {
-    compileSdk 33
-    buildToolsVersion "33.0.1"
+    compileSdk 35
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/processor/src/main/java/com/funnydevs/hilt_conductor/processor/FileGenerator.kt
+++ b/processor/src/main/java/com/funnydevs/hilt_conductor/processor/FileGenerator.kt
@@ -204,7 +204,7 @@ class FileGenerator : AbstractProcessor() {
       val injectMethodBuilder = MethodSpec.methodBuilder("inject")
         .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
         .returns(Void.TYPE)
-        .addParameter(ClassName.get(packageValue.substringBeforeLast("."), "ConductorComponentLifecycleHandler"), "handler")
+        .addParameter(ClassName.get("com.funnydevs.hilt_conductor", "ConductorComponentLifecycleHandler"), "handler")
         .addParameter(ClassName.bestGuess(whereInject.className), "controller")
 
       injectMethodBuilder.addStatement("\$T entryPoint = \$T.get(handler, \$T.class)",


### PR DESCRIPTION
After changing the app’s package name, I discovered that the annotation processor isn’t working correctly—it generates the wrong package name for the `ConductorComponentLifecycleHandler`. As a result, I started encountering the following error. This PR resolves the issue and updates all dependencies to their latest versions.

```
/Users/vladimirpetrovski/GitHub/hilt-conductor/app/build/generated/source/kapt/debug/com/example/myapplication/demo/MainController_Injector.java:3: error: cannot find symbol
import com.example.myapplication.ConductorComponentLifecycleHandler;
                                ^
  symbol:   class ConductorComponentLifecycleHandler
  location: package com.example.myapplication
/Users/vladimirpetrovski/GitHub/hilt-conductor/app/build/generated/source/kapt/debug/com/example/myapplication/demo/MainController_Injector.java:8: error: cannot find symbol
  public static void inject(ConductorComponentLifecycleHandler handler, MainController controller) {
                            ^
  symbol:   class ConductorComponentLifecycleHandler
  location: class MainController_Injector
2 errors

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:compileDebugJavaWithJavac'.
> Compilation failed; see the compiler error output for details.
```
<img width="888" alt="Screenshot 2025-02-02 at 22 08 55" src="https://github.com/user-attachments/assets/d84eaf5d-b957-4615-ae51-c11214e523ef" />